### PR TITLE
Rename HeyOrca's key

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -82,6 +82,9 @@ govnl:
 hatch:
   name: Hatch
   url: https://www.hatch.com
+heyorca:
+  name: HeyOrca
+  url: https://www.heyorca.com/
 hyke:
   name: Hyke
   url: https://hykeup.com/
@@ -243,9 +246,6 @@ wekaplex:
 waterwerks:
   name: "WaterWerks Communications"
   url: 'https://waterwerkscommunications.com/'
-whalecompany:
-  name: HeyOrca
-  url: https://www.heyorca.com/
 whiterock:
   name: "White Rock Consulting & Communications"
   url: http://www.whiterocknl.com

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -147,7 +147,7 @@
       jobs:
         - title: "Software Developer / Engineer"
           link: https://www.bluedriver.com/about-us/careers
-- company: whalecompany
+- company: heyorca
   jobs:
     -
       post_date: 2018-05-16

--- a/_posts/2018/02/2018-02-01-Weekly-Update.md
+++ b/_posts/2018/02/2018-02-01-Weekly-Update.md
@@ -20,7 +20,7 @@ categories:
 
 ## Jobs
 
-* [HeyOrca][whalecompany] is looking for a [Software Quality Assurance Specialist](https://jobs.careerbeacon.com/details/software-quality-assurance-specialist/191219)
+* [HeyOrca][heyorca] is looking for a [Software Quality Assurance Specialist](https://jobs.careerbeacon.com/details/software-quality-assurance-specialist/191219)
 and a [Full-Stack Web Developer](https://jobs.careerbeacon.com/details/fullstack-web-developer/590925).
 * [Wood Group](https://www.woodgroup.com/) is looking for a [Software Configuration Administrator / Data Manager](https://www.workopolis.com/jobsearch/job/17933675?uc=E8&sc=3.5111&sp=1).
 * [Provident10][provident] is looking for a [Data Analyst](https://www.careerbeacon.com/en/posting/724772/provident10/data-analyst/st-john-s).
@@ -39,7 +39,7 @@ and a [Network Services Technical Specialist](https://www.careerbeacon.com/en/po
 [hackinghealth]:https://www.facebook.com/HHStJohnsNL/
 [gamedevnl]:http://gamedevnl.org
 
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [bluedrop]:http://www.bluedroplearningnetworks.com/
 [chummy]:https://chummygames.com
 [colab]:https://www.colabsoftware.com/

--- a/_posts/2018/02/2018-02-08-Weekly-Update.md
+++ b/_posts/2018/02/2018-02-08-Weekly-Update.md
@@ -47,5 +47,5 @@ categories:
 [radient]:http://radient360.com/
 [subc]:http://subcimaging.com/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/02/2018-02-15-Weekly-Update.md
+++ b/_posts/2018/02/2018-02-15-Weekly-Update.md
@@ -53,7 +53,7 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [radient]:http://radient360.com/
 [subc]:http://subcimaging.com/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/
 [nlchi]:https://www.nlchi.nl.ca/
 [triware]:http://triware.ca/

--- a/_posts/2018/02/2018-02-22-Weekly-Update.md
+++ b/_posts/2018/02/2018-02-22-Weekly-Update.md
@@ -23,7 +23,7 @@ categories:
 
 ## New Job Postings
 
-* [HeyOrca][whalecompany] is looking for a [Senior UX Designer](https://jobs.careerbeacon.com/details/senior-ux-designer/1099612) and a [Experienced Software Developer](https://jobs.careerbeacon.com/details/experienced-software-developer/590925).
+* [HeyOrca][heyorca] is looking for a [Senior UX Designer](https://jobs.careerbeacon.com/details/senior-ux-designer/1099612) and a [Experienced Software Developer](https://jobs.careerbeacon.com/details/experienced-software-developer/590925).
 * [Verafin][verafin] is looking for a [Technical Support Specialist](https://www.careerbeacon.com/en/posting/729868/verafin/technical-support-specialist/st-john-s).
 
 View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
@@ -51,7 +51,7 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [radient]:http://radient360.com/
 [subc]:http://subcimaging.com/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/
 [nlchi]:https://www.nlchi.nl.ca/
 [triware]:http://triware.ca/

--- a/_posts/2018/03/2018-03-01-Weekly-Update.md
+++ b/_posts/2018/03/2018-03-01-Weekly-Update.md
@@ -57,5 +57,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/03/2018-03-08-Weekly-Update.md
+++ b/_posts/2018/03/2018-03-08-Weekly-Update.md
@@ -53,5 +53,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/03/2018-03-15-Weekly-Update.md
+++ b/_posts/2018/03/2018-03-15-Weekly-Update.md
@@ -60,5 +60,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/03/2018-03-22-Weekly-Update.md
+++ b/_posts/2018/03/2018-03-22-Weekly-Update.md
@@ -59,5 +59,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/03/2018-03-29-Weekly-Update.md
+++ b/_posts/2018/03/2018-03-29-Weekly-Update.md
@@ -63,5 +63,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/04/2018-04-05-Weekly-Update.md
+++ b/_posts/2018/04/2018-04-05-Weekly-Update.md
@@ -67,5 +67,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [subc]:http://subcimaging.com/
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/04/2018-04-12-Weekly-Update.md
+++ b/_posts/2018/04/2018-04-12-Weekly-Update.md
@@ -83,5 +83,5 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
 [wekaplex]:http://www.wekaplex.com/
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/04/2018-04-19-Weekly-Update.md
+++ b/_posts/2018/04/2018-04-19-Weekly-Update.md
@@ -74,6 +74,6 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
 [wekaplex]:http://www.wekaplex.com/
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [wood]:https://www.woodplc.com
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/04/2018-04-26-Weekly-Update.md
+++ b/_posts/2018/04/2018-04-26-Weekly-Update.md
@@ -81,6 +81,6 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
 [wekaplex]:http://www.wekaplex.com/
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [wood]:https://www.woodplc.com
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/05/2018-05-03-Weekly-Update.md
+++ b/_posts/2018/05/2018-05-03-Weekly-Update.md
@@ -78,6 +78,6 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
 [wekaplex]:http://www.wekaplex.com/
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [wood]:https://www.woodplc.com
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/05/2018-05-10-Weekly-Update.md
+++ b/_posts/2018/05/2018-05-10-Weekly-Update.md
@@ -76,6 +76,6 @@ View more jobs on our [Jobs Page]({{ site.url }}{{ site.baseurl }}/jobs)!
 [triware]:http://triware.ca/
 [verafin]:https://verafin.com
 [wekaplex]:http://www.wekaplex.com/
-[whalecompany]:https://www.heyorca.com/
+[heyorca]:https://www.heyorca.com/
 [wood]:https://www.woodplc.com
 [zedit]:http://www.zedit.com/

--- a/_posts/2018/12/2018-12-13-Weekly-Update.md
+++ b/_posts/2018/12/2018-12-13-Weekly-Update.md
@@ -17,7 +17,7 @@ jobs:
   jobs:
     - title: Intermediate Software Developers
       link: https://www.workopolis.com/jobsearch/viewjob/KiB7e6YTUJUveUusnk5vLK2aE_4U-qcBYxk1H4njbnFxPX0HNWXzgw
-- company: whalecompany
+- company: heyorca
   jobs:
     - title: Software Developer (Coop)
       link: https://www.workopolis.com/jobsearch/viewjob/kr_m61N82uihQSj_y1iklEfixDd7nrFWcrqHxARSLawGifeIuKsr2w

--- a/_posts/2019/02/2019-02-28-Weekly-Update.md
+++ b/_posts/2019/02/2019-02-28-Weekly-Update.md
@@ -9,7 +9,7 @@ categories:
     - news
 
 jobs:
-- company: whalecompany
+- company: heyorca
   jobs:
     - title: Software Engineer
       link: https://www.workopolis.com/jobsearch/viewjob/zpC11ww-l6bBlH8lHsOgMNeaaTJb92NIpQktqANCFgHiYfc3p2UDgQ

--- a/_posts/2019/05/2019-05-16-Weekly-Update.md
+++ b/_posts/2019/05/2019-05-16-Weekly-Update.md
@@ -21,7 +21,7 @@ jobs:
   jobs:
     - title: "Junior Full Stack Developer"
       link: "https://www.workopolis.com/jobsearch/viewjob/qNA-LvHfuM75qEG7AzkhDr1JQEJ5ybHAoXDEEtKVe1UU7A5z46fsgw"
-- company: whalecompany
+- company: heyorca
   jobs:
     - title: Software Quality Assurance Engineer (Co-op)
       link: https://www.workopolis.com/jobsearch/viewjob/qwdh-7R00ftjVN_C8iVFdPdfTgNTtsWqQcSKgCGXRheTOrFDsHIR_Q


### PR DESCRIPTION
# What

HeyOrca was one of the first companies to have jobs posted to the website. At that time it was called whalecompany, but since the list has grown and other companies have not been given nicknames, it makes sense to properly rename the key for HeyOrca.

This change replaces all occurrences of "whalecompany" with "heyorca".