### PR TITLE
Add feb 9th 2022 digital meetup event

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -7,4 +7,6 @@
 #  });
 #  console.log(o.join('\n'))
 
-[]
+- title: "Digital Meetup (via gather.town)"
+  start: "2022-02-09T19:00:00-03:30"
+  url: https://ctsnl.slack.com/archives/CKD25AS6B/p1643909031343229


### PR DESCRIPTION
Just made it a link directly to my message in Slack, since if you visit it not logged in it will bring you to a sign-in page

![image](https://user-images.githubusercontent.com/6486417/152413448-3e6d5f14-1391-4621-94e4-9c681f507621.png)

I assume when you do the next weekly digest post you can reference this event in it :+1: , would be nice to have the poster baked in as well if possible.