### PR TITLE
fix: Update link to Azure Solutions Architect for Mariner

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -84,7 +84,7 @@
           link: https://www.smartrecruiters.com/MarinerPartnersInc/743999834056922--net-developer
           remote: true
         - title: Azure Solutions Architect
-          link: https://www.smartrecruiters.com/MarinerPartnersInc/743999834056922--net-developer
+          link: https://jobs.smartrecruiters.com/MarinerPartnersInc/743999783599410-azure-solutions-architect
           remote: true
     -
       post_date: 2022-03-25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.2'
+
 services:
   jekyll:
       image: jekyll/jekyll:3.8


### PR DESCRIPTION
This should resolve duplicate url build error:
https://github.com/CTS-NL/CTS-NL.github.io/runs/7041620755?check_suite_focus=true

Also, added docker compose reference file version. Without it, received this error:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'jekyll'
```

https://stackoverflow.com/a/45999898/583830
