### PR TITLE
remove mention of slack / join slack links in most places

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -220,7 +220,7 @@ johnson:
   url: https://www1.johnson.ca/
   local: true
 keyassets:
-  name: 'Key Assets Newfoundland & Labrador'
+  name: "Key Assets Newfoundland & Labrador"
   url: https://www.keyassetsnl.ca/
   local: true
 kraken:
@@ -305,7 +305,7 @@ m5:
   url: https://m5.ca/
   canadian: true
 mobia:
-  name: 'MOBIA Technology Innovations'
+  name: "MOBIA Technology Innovations"
   url: "https://mobia.io/"
 oliverpos:
   name: Oliver POS
@@ -470,16 +470,6 @@ triware:
   name: Triware Technologies Inc.
   url: http://triware.ca/
   local: true
-# Venor is a talent/recruitment company, but they are active in our Slack so I am allowing them - Tim
-venor:
-  name: Venor
-  note: |
-    Venor is a local talent agency that is active within the CTS-NL community.
-
-
-    If you are looking to apply, you can also direct message `@JF Ratthé` in the [CTS-NL Slack](https://join.slack.com/t/ctsnl/shared_invite/enQtNzE5Mzc1OTA3ODI2LTdhODg1ZTQ4YTMwNDRkYzI2OWZjOTZmYWZjNjA3N2QzMTRiZWEyNmI0MTRmYjNjMDFhZGUxNzlhY2I5YjEwMTk).
-  url: https://venor.ca/
-  canadian: true
 verafin:
   name: Verafin
   url: https://verafin.com
@@ -502,7 +492,7 @@ wekaplex:
   canadian: true
 waterwerks:
   name: "WaterWerks Communications"
-  url: 'https://waterwerkscommunications.com/'
+  url: "https://waterwerkscommunications.com/"
   local: true
 westernhealth:
   name: Western Health

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,11 +18,6 @@
   url: "http://discord.ctsnl.ca/"
   side: left
 
-- title: Join Slack
-  url: "https://join.slack.com/t/ctsnl/shared_invite/enQtNzE5Mzc1OTA3ODI2LTdhODg1ZTQ4YTMwNDRkYzI2OWZjOTZmYWZjNjA3N2QzMTRiZWEyNmI0MTRmYjNjMDFhZGUxNzlhY2I5YjEwMTk"
-  side: left
-
-
 - title: Events
   url: "/events/"
   side: right

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -3,7 +3,6 @@
 		<h3>Important Links</h3>
 		<ul class="side-nav" role="navigation" >
 			<li role="menuitem"><a href="http://discord.ctsnl.ca/">Join Discord</a></li>
-			<li role="menuitem"><a href="https://join.slack.com/t/ctsnl/shared_invite/enQtNzE5Mzc1OTA3ODI2LTdhODg1ZTQ4YTMwNDRkYzI2OWZjOTZmYWZjNjA3N2QzMTRiZWEyNmI0MTRmYjNjMDFhZGUxNzlhY2I5YjEwMTk">Join Slack</a></li>
 			<li role="menuitem"><a href="https://github.com/CTS-NL">GitHub Organization</a></li>
 		</ul>
 	</div>

--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -16,22 +16,6 @@
 /* Custom
 ------------------------------------------------------------------- */
 
-#slack-loading {
-  width: 300px;
-  height: 300px;
-  margin: auto;
-  overflow: hidden;
-  text-align: center;
-  font-weight: bold;
-}
-
-#slack-invite-wrapper {
-  text-align: center;
-}
-#slack-invite {
-  display: none;
-}
-
 .loader,
 .loader:after {
   border-radius: 50%;

--- a/pages/code-of-conduct.md
+++ b/pages/code-of-conduct.md
@@ -1,24 +1,23 @@
 ---
 layout: page-fullwidth
 subheadline: "CTS-NL"
-title:  "Code of Conduct"
+title: "Code of Conduct"
 teaser: ""
 header:
-    image: "logo.png"
-    pattern: "header-texture.png"
+  image: "logo.png"
+  pattern: "header-texture.png"
 permalink: "/conduct/"
 ---
 
-All attendees, speakers, sponsors and volunteers at our meetups, in our Slack Channel and on our Facebook group are
+All attendees, speakers, sponsors and volunteers at our meetups, in our Discord, and on our Facebook group are
 required to agree with the following code of conduct. The executive members will enforce this code throughout all
-our events, Facebook group and our Slack channel. We expect cooperation from all participants to help ensure a safe
+our events, Facebook group and our Discord. We expect cooperation from all participants to help ensure a safe
 environment for everybody.
-
 
 ## Need Help?
 
-Contact a member of the executive or organizer of any event. In Slack, the executive can be identified by the crown
-next to their names. The executive can also be reached by email at contact@ctsnl.ca.
+Contact a member of the executive or organizer of any event. In Discord, the executive can be identified by the
+role next to their names. The executive can also be reached by email at contact@ctsnl.ca.
 
 ## Purpose
 
@@ -52,8 +51,8 @@ If a participant engages in harassing behavior, the CTS-NL Executive Members wil
 including warning the offender or expulsion from the meetup, event or online forum with no refund.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a
-CTS-NL Executive Member immediately. Executive Members can be identified with a crown in Slack and can be identified to
-by any event organizer or volunteer.
+CTS-NL Executive Member immediately. Executive Members can be identified by the role next to their name and can be
+identified to by any event organizer or volunteer.
 
 The CTS-NL Executive Members will be happy to help participants contact hotel/venue security or local law enforcement,
 provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the CTS-NL meetups
@@ -68,15 +67,14 @@ We expect participants to follow these rules at all CTS-NL meetups, events, and 
 
 If you wish to report violations of our code of conduct:
 
-* Find a Executive Member, organizer, or volunteer
-* Describe the incident to the best of your ability
-* An Executive Member will approach the offender and inform them of the behaviour and ask them to stop, your anonymity
-will be respected
-
+- Find a Executive Member, organizer, or volunteer
+- Describe the incident to the best of your ability
+- An Executive Member will approach the offender and inform them of the behaviour and ask them to stop, your anonymity
+  will be respected
 
 If the offender refuses to stop the behaviour or repeats it, they will be expelled immediately.
 
-If the behaviour is judged too threatening, the offender may be expelled immediately at the discretion of the 
+If the behaviour is judged too threatening, the offender may be expelled immediately at the discretion of the
 Executive Members. Examples include but are not limited to: cat-calling and overt aggressive behaviour.
 
 ## Reminder


### PR DESCRIPTION
- some random quotes changed due to my editors yml formatter
- removed venor, they have not been active in some time, and it was
  referencing a slack link, so i remove
- join slack buttons in nav and sidebar gone
- some already dead css mentioning slack removed
- minor changes to the code of conduct to remove slack references and
  reference discord instead, this file should probably be revised to
  remove references to things like the Facebook group as well, but
  that is outside the scope of this PR
- _posts still has slack links, but its mostly the weekly posts
