### PR TITLE
Add llms.txt information file

### DIFF
--- a/pages/pages-root-folder/llms.txt
+++ b/pages/pages-root-folder/llms.txt
@@ -1,0 +1,17 @@
+---
+layout: null
+title: "Information file for LLMs"
+permalink: /llms.txt
+---
+# {{ site.title }}
+
+> {{ site.description }}
+
+## Pages
+
+{% for page in site.pages %}{% if page.path contains 'pages/' %}{% unless page.path contains 'pages-root-folder/' %}- [{{ page.title }}]({{ site.url }}{{ site.baseurl }}{{ page.permalink }})
+{% endunless %}{% endif %}{% endfor %}
+## Posts
+
+{% for post in site.posts limit:10 %}- [{{ post.title }}]({{ site.url }}{{ site.baseurl }}{{ post.url }})
+{% endfor %}


### PR DESCRIPTION
Adds a LLM-friendly information file using this proposed standard: https://llmstxt.org/. Currently links to the site's main pages as well as the 10 most recent posts.